### PR TITLE
Change import to github.com

### DIFF
--- a/gui/gui.go
+++ b/gui/gui.go
@@ -5,13 +5,13 @@ import (
 	"runtime"
 	"time"
 
-	"gitlab.com/liamg/raft/glfont"
+	"github.com/liamg/raft/glfont"
 
 	"github.com/go-gl/gl/all-core/gl"
 	"github.com/go-gl/glfw/v3.2/glfw"
-	"gitlab.com/liamg/raft/buffer"
-	"gitlab.com/liamg/raft/config"
-	"gitlab.com/liamg/raft/terminal"
+	"github.com/liamg/raft/buffer"
+	"github.com/liamg/raft/config"
+	"github.com/liamg/raft/terminal"
 	"go.uber.org/zap"
 )
 

--- a/gui/mouse.go
+++ b/gui/mouse.go
@@ -5,7 +5,7 @@ import (
 	"math"
 
 	"github.com/go-gl/glfw/v3.2/glfw"
-	"gitlab.com/liamg/raft/terminal"
+	"github.com/liamg/raft/terminal"
 )
 
 func (gui *GUI) mouseButtonCallback(w *glfw.Window, button glfw.MouseButton, action glfw.Action, mod glfw.ModifierKey) {

--- a/gui/renderer.go
+++ b/gui/renderer.go
@@ -4,9 +4,9 @@ import (
 	"math"
 
 	"github.com/go-gl/gl/all-core/gl"
-	"gitlab.com/liamg/raft/buffer"
-	"gitlab.com/liamg/raft/config"
-	"gitlab.com/liamg/raft/glfont"
+	"github.com/liamg/raft/buffer"
+	"github.com/liamg/raft/config"
+	"github.com/liamg/raft/glfont"
 )
 
 type OpenGLRenderer struct {

--- a/main.go
+++ b/main.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/kr/pty"
 	"github.com/riywo/loginshell"
-	"gitlab.com/liamg/raft/config"
-	"gitlab.com/liamg/raft/gui"
-	"gitlab.com/liamg/raft/terminal"
+	"github.com/liamg/raft/config"
+	"github.com/liamg/raft/gui"
+	"github.com/liamg/raft/terminal"
 	"go.uber.org/zap"
 )
 

--- a/terminal/sgr.go
+++ b/terminal/sgr.go
@@ -3,7 +3,7 @@ package terminal
 import (
 	"fmt"
 
-	"gitlab.com/liamg/raft/buffer"
+	"github.com/liamg/raft/buffer"
 )
 
 func sgrSequenceHandler(params []string, intermediate string, terminal *Terminal) error {

--- a/terminal/terminal.go
+++ b/terminal/terminal.go
@@ -10,8 +10,8 @@ import (
 	"syscall"
 	"unsafe"
 
-	"gitlab.com/liamg/raft/buffer"
-	"gitlab.com/liamg/raft/config"
+	"github.com/liamg/raft/buffer"
+	"github.com/liamg/raft/config"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
Changes the import from `gitlab.com` to `github.com`.

Without this Go gets confused.

```
main.go:13:2: cannot find package "gitlab.com/liamg/raft/config" in any of:
	/home/moscar/projects/go/src/github.com/liamg/raft/vendor/gitlab.com/liamg/raft/config (vendor tree)
	/usr/lib/go/src/gitlab.com/liamg/raft/config (from $GOROOT)
	/home/moscar/projects/go/src/gitlab.com/liamg/raft/config (from $GOPATH)
main.go:14:2: cannot find package "gitlab.com/liamg/raft/gui" in any of:
	/home/moscar/projects/go/src/github.com/liamg/raft/vendor/gitlab.com/liamg/raft/gui (vendor tree)
	/usr/lib/go/src/gitlab.com/liamg/raft/gui (from $GOROOT)
	/home/moscar/projects/go/src/gitlab.com/liamg/raft/gui (from $GOPATH)
main.go:15:2: cannot find package "gitlab.com/liamg/raft/terminal" in any of:
	/home/moscar/projects/go/src/github.com/liamg/raft/vendor/gitlab.com/liamg/raft/terminal (vendor tree)
	/usr/lib/go/src/gitlab.com/liamg/raft/terminal (from $GOROOT)
	/home/moscar/projects/go/src/gitlab.com/liamg/raft/terminal (from $GOPATH)
```